### PR TITLE
Pin actions to hashes using pinact [workflow-enforcer]

### DIFF
--- a/.github/workflows/shipit.yml
+++ b/.github/workflows/shipit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: build it
         run: |
           yarn install && yarn build


### PR DESCRIPTION
This PR pins action references to commit hashes to mitigate supply chain attacks where a bad actor will push a new tag or override an existing tag, leading to us running malicious code immediately without explicitly updating.

Documentation on how to use pinact can be found in the internal developers site.
